### PR TITLE
Database unavailable when pet clinic starts

### DIFF
--- a/Dockerfile-db
+++ b/Dockerfile-db
@@ -3,5 +3,10 @@
 ####
 
 FROM mysql:5.7
+
+####
+#### this Dockerfile is used to build a mysql image with prepared data in it
+####
+
 ARG data_directory
-ADD $data_directory /var/lib/mysql
+ADD $data_directory/mysql /var/lib/mysql


### PR DESCRIPTION
On my system, I could not get the MySQL image to start up correctly. It seems that there was a wrong path when doing ``docker cp``.
